### PR TITLE
Update filelist-bindings.tcl

### DIFF
--- a/library/filelist-bindings.tcl
+++ b/library/filelist-bindings.tcl
@@ -1059,7 +1059,9 @@ proc ::TreeCtrl::EditClose {T type accept {refocus 0}} {
 	     E $Priv($type,$T,element)]
 
     if {$refocus} {
-	focus $Priv($type,$T,focus)
+	    if {[winfo exists Priv($type,$T,focus)]} {
+	      focus $Priv($type,$T,focus)
+	    }
     }
 
     return


### PR DESCRIPTION
There is a bug in treectrl, when an item is edited. The Priv($type,$T,focus) variable stores the window path that had the focus before editing. If that window no longer exists, then the proc returns an error.